### PR TITLE
refine search button in sidebar disabled when queue empty

### DIFF
--- a/client/src/views/ViewSidebar.js
+++ b/client/src/views/ViewSidebar.js
@@ -77,6 +77,9 @@ export default withRouter(function ViewSidebar(props) {
                 <ListItem 
                     button
                     onClick={handleRefineClick}
+                    disabled={props.props.searchQueue.length === 0 ?
+                        true :
+                        false}
                 >
                     <ListItemText primary="Refine Search" />
                 </ListItem>


### PR DESCRIPTION
Missed adding this before the last PR.