### PR TITLE
Drop tagline add space between logo and search bar

### DIFF
--- a/client/src/home-page/HomePage.js
+++ b/client/src/home-page/HomePage.js
@@ -15,9 +15,11 @@ const useStyles = makeStyles({
     height: "inherit",
     width: "inherit",
   },
-  search: {
-    marginTop: "10px",
-    marginBottom: "10px",
+  aboutLink: {
+    position: "absolute",
+    top: "15px",
+    left: "20px",
+    fontSize: "14px",
   },
   logo: {
     display: "block",
@@ -26,16 +28,9 @@ const useStyles = makeStyles({
     maxWidth: "50%",
     height: "auto",
   },
-  aboutLink: {
-    position: "absolute",
-    top: "15px",
-    left: "20px",
-    fontSize: "14px"
+  search: {
+    marginTop: "45px",
   }
-  // tagline: {
-  //   color: theme.palette.primary.main,
-  //   marginBottom: "15vh"
-  // }
 })
 
 export default function HomePage({ props }) {
@@ -70,17 +65,6 @@ export default function HomePage({ props }) {
               <SearchBar props={props} />
             </Grid>
 
-          </Grid>
-
-          <Grid item>
-            <Typography 
-              style={{
-                color: theme.palette.primary.main,
-                marginBottom: "15vh"
-              }} // This should be in `makeStyles` but it doesn't work...?
-            >
-              A powerfully intuitive way to search the scientific literature
-            </Typography>
           </Grid>
 
         </Grid>


### PR DESCRIPTION
# Overview

This is just meant to be a simple PR to clean up the homepage a little. Mostly so I can get back into the swing of things. Changes:

- Dropped the tagline. I think I was the one who originally added this, but it seems cheesy and definitely isn't serving any functional purpose.
- Add spacing between the logo and search bar, previously it looked cramped.

Some questions @duncster94 :

- Am I merging to the right branch?
- How do I change the colour of the about link? I tried setting the `color` property under `makeStyles` and pointing it to one of the colours in `Theme.js`, but this didn't work.
- Any idea why the logo is centering horizontally? I looked at a bunch of search engines and the search bar is always about 1/3 down the page. 