### PR TITLE
drop box shadow and increase button size

### DIFF
--- a/client/src/home-page/SearchBar.js
+++ b/client/src/home-page/SearchBar.js
@@ -128,7 +128,7 @@ export default withRouter(function SearchBar(props) {
         colors: {
           ...theme_.colors,
           primary: theme.palette.primary.main,
-          primary25: theme.palette.primary.mainLight
+          primary25: "#eeeeee"
         }
       })}
       styles={{
@@ -185,8 +185,7 @@ function MenuSearchButtons({ props }) {
     >
       <ButtonGroup
         variant="text"
-        size="small"
-        style={{boxShadow: "0px 0px 0px 0px"}}
+        size="large"
       >
         <Button
           aria-haspopup="true"


### PR DESCRIPTION
This PR just makes some small changes to the search bar aethetics:

- remove box-shadow that caused each button edged to be outlined.
- Set button size to `large`. The highlight/wave affect from Material UI now takes fills up the entire space around the button.
- Set the color of a paper currently highlighted in the search bar to `#eee` (same as google)

__Before__

![Screen Shot 2020-01-18 at 1 25 52 PM](https://user-images.githubusercontent.com/8917831/72668636-09107400-39f7-11ea-8ae7-14f95cec9700.png)

__After__

![Screen Shot 2020-01-18 at 1 26 31 PM](https://user-images.githubusercontent.com/8917831/72668639-0f9eeb80-39f7-11ea-8751-82d0c75049c4.png)
