### PR TITLE
prevent search dropdown from creating scrollbars on homepage

### DIFF
--- a/client/src/home-page/HomePage.js
+++ b/client/src/home-page/HomePage.js
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
     flexGrow: 1,
     height: "inherit",
     width: "inherit",
+    overflow: 'hidden'
   },
   aboutLink: {
     position: "absolute",


### PR DESCRIPTION
This is a quick fix to prevent the search bar option dropdown from creating scroll bars on the homepage when it overflows. In the future we should figure out how to properly set the height of the dropdown because right now it's being cut off. Not a huge deal but it should be fixed in the future.