### PR TITLE
moves node colouring from backend to front end for greater separation…

### DIFF
--- a/client/src/utils/dateToColour.js
+++ b/client/src/utils/dateToColour.js
@@ -1,0 +1,36 @@
+export default function dateToColour(nodes, dMin, dMax, seeds) {
+  /* Given a node, map the appropriate colour.
+  */
+
+  return nodes.map(node => {
+
+    // If the node is a seed node, colour it differently.
+    if (seeds.includes(node.id.toString())) {
+      return '#000000'
+    }
+  
+    // Get publication year.
+    let year = node.PubDate.Year
+  
+    // If publication year is not available, set node colour to
+    // grey.
+    if (!year) {
+      return '#ccc'
+    }
+  
+    // Define minimum and maximum lightness.
+    let lMin = 50
+    let lMax = 100
+  
+    // Get lightness of node colour based on date.
+    let m = (lMax - lMin) / (dMin - dMax)
+    let b = lMax - m * dMin
+  
+    let lightness = m * year + b
+  
+    let colour = `hsla(0,0%, ${lightness.toString()}%,1)`
+  
+    return colour
+  })
+
+}

--- a/client/src/views/NetworkView.js
+++ b/client/src/views/NetworkView.js
@@ -6,6 +6,7 @@ import PopupModal from "./PopupModal"
 import "./NetworkView.css"
 
 import theme from "../Theme"
+import dateToColour from '../utils/dateToColour'
 
 export default function NetworkView({ props }) {
   console.log(props.searchResults)
@@ -26,6 +27,14 @@ export default function NetworkView({ props }) {
   }
 
   React.useEffect(() => {
+
+    const { minDate, maxDate } = props.searchResults.metadata
+    const colours = dateToColour(
+      props.searchResults.subgraph.nodes, 
+      minDate, 
+      maxDate, 
+      props.searchQueue
+    )
 
     const svg = d3.select(svgRef.current)
     const g = svg.append("g") // Group to hold elements
@@ -97,10 +106,12 @@ export default function NetworkView({ props }) {
         return props.searchResults.metadata.radii[idx]
       })
       .attr("fill", function(_, idx) {
-        return props.searchResults.metadata.colours[idx]
+        // return props.searchResults.metadata.colours[idx]
+        return colours[idx]
       })
       .attr("stroke", function(_, idx) {
-        const lightness = props.searchResults.metadata.colours[idx].split(",")[2]
+        // const lightness = props.searchResults.metadata.colours[idx].split(",")[2]
+        const lightness = colours[idx].split(",")[2]
         if (lightness && 
           parseFloat(lightness.replace("%", "").replace(" ", "")) >= 90) {
           return "#ddd"

--- a/client/src/views/RankView.js
+++ b/client/src/views/RankView.js
@@ -9,6 +9,7 @@ import { debounce } from 'debounce'
 
 import ViewDialog from "./ViewDialog"
 import PopupModal from "./PopupModal"
+import dateToColour from '../utils/dateToColour'
 import "./RankView.css"
 
 import theme from "../Theme"
@@ -45,6 +46,14 @@ export default function RankView({ props }) {
   const lhsRef = React.useRef(null)
   const paperInfoHeight = 175.0 // height of left-hand side paper info cards
   const maxRadius = Math.max(...props.searchResults.metadata.radii)
+
+  const { minDate, maxDate } = props.searchResults.metadata
+  const colours = dateToColour(
+    props.searchResults.subgraph.nodes, 
+    minDate, 
+    maxDate, 
+    props.searchQueue
+  )
 
   // Currently no Javascript hooks exist for CSS snap scroll events so
   // for now the `scrollTop` pixel values must be tracked to determine which
@@ -133,7 +142,7 @@ export default function RankView({ props }) {
               }
 
               // Put darker border around light coloured nodes.
-              const lightness = props.searchResults.metadata.colours[i].split(",")[2]
+              const lightness = colours[i].split(",")[2]
               let stroke
               if (lightness && 
                 parseFloat(lightness.replace("%", "").replace(" ", "")) >= 90) {
@@ -163,7 +172,7 @@ export default function RankView({ props }) {
                       cx={maxRadius + 2}
                       cy={(paperInfoHeight / 2) + 2}
                       r={props.searchResults.metadata.radii[i]}
-                      fill={props.searchResults.metadata.colours[i]}
+                      fill={colours[i]}
                       stroke={stroke}
                       strokeWidth="2.5px"
                       onClick={handleNodeClick(i * paperInfoHeight)}

--- a/process-subnetwork.js
+++ b/process-subnetwork.js
@@ -16,8 +16,8 @@ function processSubnetwork(message, seeds) {
       dates.push(pub_year);
     }
   })
-  let min_date = Math.min(...dates)
-  let max_date = Math.max(...dates)
+  let minDate = Math.min(...dates)
+  let maxDate = Math.max(...dates)
 
   function scoreToRadius(node, seeds) {
     /* Given a node, take its score and map it to a radius.
@@ -30,39 +30,6 @@ function processSubnetwork(message, seeds) {
       radius = 15
     }
     return Math.max(5, radius)
-  }
-
-  function dateToColour(node, D_min, D_max, seeds) {
-    /* Given a node, map the appropriate colour.
-    */
-
-    // If the node is a seed node, colour it differently.
-    if (seeds.includes(node.id.toString())) {
-      return '#9D0000'
-    }
-
-    // Get publication year.
-    let year = node.PubDate.Year
-
-    // If publication year is not available, set node colour to
-    // grey.
-    if (!year) {
-      return '#ccc'
-    }
-
-    // Define minimum and maximum lightness.
-    L_min = 50
-    L_max = 100
-
-    // Get lightness of node colour based on date.
-    let m = (L_max - L_min) / (D_min - D_max)
-    let b = L_max - m * D_min
-
-    let lightness = m * year + b
-
-    let colour = `hsla(0,0%, ${lightness.toString()}%,1)`
-
-    return colour
   }
 
   function formatAuthors(authors) {
@@ -204,10 +171,6 @@ function processSubnetwork(message, seeds) {
     return scoreToRadius(node, seeds)
   })
 
-  const colours = message.subgraph.nodes.map(node => {
-    return dateToColour(node, min_date, max_date, seeds)
-  })
-
   message.subgraph.nodes.forEach(node => {
     node.formattedAuthors = formatAuthors(node.Authors)
   })
@@ -225,7 +188,8 @@ function processSubnetwork(message, seeds) {
     seeds, 
     metadata: {
       radii,
-      colours
+      minDate,
+      maxDate
     }
   })
 }


### PR DESCRIPTION
… of concerns

This PR moves the `dateToColour` function into the front end to allow for completely client-side styling and greater separation of concerns. This should be done with all backend styling functions located in `process-subnetwork` in the future.