### PR TITLE
bump seed node size

### DIFF
--- a/process-subnetwork.js
+++ b/process-subnetwork.js
@@ -27,7 +27,7 @@ function processSubnetwork(message, seeds) {
 
     // Set seed nodes to a fixed size.
     if (seeds.includes(node.id)) {
-      radius = 15
+      radius = 32.5
     }
     return Math.max(5, radius)
   }


### PR DESCRIPTION
This PR just hardcodes the seed node size to be a tiny bit larger than all other nodes in the network. Because node size ~ relevance, I think it may have been confusing to users that the seed nodes were smaller than other nodes.

@duncster94 I was between this and making the seed node the same size as the largest non-seed node in the network. Any preference?