### PR TITLE
removed react transition group, got view switching for free

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { withRouter, Route, Switch, Redirect } from "react-router-dom"
-import { TransitionGroup, CSSTransition } from "react-transition-group"
 import { MuiThemeProvider } from "@material-ui/core/styles"
 
 import "./App.css"
@@ -33,25 +32,13 @@ export default withRouter(function App(props) {
 
   return (
     <MuiThemeProvider theme={theme}>
-      <TransitionGroup component={null}> {/* `null` component avoids wrapper div */}
-        <CSSTransition
-          key={props.location.key}
-          timeout={1000}
-          classNames="fade-transition"
-          unmountOnExit
-          appear
-        >
-
-          <Switch location={props.location}>
-            <Route exact path="/" render={() => <HomePage props={homePageProps} />} />
-            <Route path="/about" component={AboutPage} />
-            <Route path="/view/:view" component={View} />
-            <Route path="/404" component={GenericNotFound} />
-            <Redirect to="/404" />
-          </Switch>
-
-        </CSSTransition>
-      </TransitionGroup>
+      <Switch >
+        <Route exact path="/" render={() => <HomePage props={homePageProps} />} />
+        <Route path="/about" component={AboutPage} />
+        <Route path="/view/:view" component={View} />
+        <Route path="/404" component={GenericNotFound} />
+        <Redirect to="/404" />
+      </Switch>
     </MuiThemeProvider>
   )
 })

--- a/client/src/views/View.js
+++ b/client/src/views/View.js
@@ -3,7 +3,7 @@ import React from "react"
 import Grid from "@material-ui/core/Grid"
 import CircularProgress from "@material-ui/core/CircularProgress"
 
-import { Redirect } from "react-router-dom"
+import { Redirect, withRouter } from "react-router-dom"
 
 import queryString from "query-string"
 
@@ -13,7 +13,7 @@ import RankView from "./RankView"
 import NetworkView from "./NetworkView"
 import "./View.css"
 
-export default function View(props) {
+function View(props) {
 
   const [redirect, setRedirect] = React.useState(false)
   const [searchResults, setSearchResults] = React.useState(null)
@@ -33,6 +33,7 @@ export default function View(props) {
       setRedirect(true)
 
     } else {
+      setSearchResults(null)
 
       // Put singleton in array.
       if (!Array.isArray(paperIDs.id)) {
@@ -58,7 +59,7 @@ export default function View(props) {
 
       submitPaper()
     }
-  }, [])
+  }, [props.location.search])
 
   function handleReadNodeClick(clickedNodeId) {
     // const clickedNodeId = pixelIntervals[interval].id
@@ -149,3 +150,5 @@ function LoadingIndicator() {
     </div>
   )
 }
+
+export default withRouter(View)


### PR DESCRIPTION
This PR removes `react-transition-group`, so no more fades between pages. 

CiteNet:
- feels like it responds much faster now
- has no UI glitches due to transition group and
- amazingly, view switching between rank and network view is now instant.

