### PR TITLE
modified CiteNet to work with preprints

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1469,9 +1469,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",
@@ -2303,9 +2303,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -3149,8 +3149,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -5295,9 +5294,9 @@
           }
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -6530,8 +6529,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -7041,9 +7039,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -8193,8 +8191,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8231,8 +8228,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -8241,8 +8237,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8345,8 +8340,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8356,7 +8350,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8376,13 +8369,11 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8399,7 +8390,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8480,8 +8470,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8491,7 +8480,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8567,8 +8555,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8598,7 +8585,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8616,7 +8602,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8655,13 +8640,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -9602,9 +9585,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -9857,9 +9840,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -12827,9 +12810,9 @@
           }
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "shallow-clone": {
           "version": "3.0.1",
@@ -13236,8 +13219,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -41,5 +41,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://192.168.3.186:3002"
+  "proxy": "http://localhost:3002"
 }

--- a/client/src/home-page/SearchBar.js
+++ b/client/src/home-page/SearchBar.js
@@ -5,6 +5,8 @@ import { withRouter } from "react-router-dom"
 import Box from "@material-ui/core/Box"
 import Button from "@material-ui/core/Button"
 import ButtonGroup from "@material-ui/core/ButtonGroup"
+import Divider from "@material-ui/core/Divider"
+import Grid from "@material-ui/core/Grid"
 import ListSubheader from "@material-ui/core/ListSubheader"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import Menu from "@material-ui/core/Menu"
@@ -30,13 +32,6 @@ const viewOptions = [
   "Network"
 ]
 
-const optionStyles = {
-  root: {
-    display: "flex",
-    flexDirection: "column"
-  }
-}
-
 export default withRouter(function SearchBar(props) {
 
   const { 
@@ -49,26 +44,43 @@ export default withRouter(function SearchBar(props) {
   function formatOptionLabel(values) {
     // Custom option component
 
-    console.log(values)
     const authorString = values.labels.Authors.map(function (element) {
+      if (element.Initials === undefined) {
+        return element.LastName
+      }
       return `${element.Initials} ${element.LastName}`
     }).join(", ")
     return (
-      <div style={optionStyles.root}>
-        <Typography
-          variant="body2"
-          color="textPrimary"
+      // <div style={optionStyles.root}>
+      <Grid container>
+        <Grid item xs={values.labels.is_preprint ? 10 : 12}>
+          <Typography variant="body1" color="textPrimary">
+            {values.labels.Title}
+          </Typography>
+        </Grid>
+
+        <Grid
+          item
+          xs={2}
+          style={{
+            display: values.labels.is_preprint ? "block" : "none"
+          }}
         >
-          {values.labels.Title}
-        </Typography>
-        <Typography
-          variant="subtitle2"
-          color="textSecondary"
-        >
-          {authorString}
-        </Typography>
-      </div>
-    )
+          <Box fontStyle="italic" color={theme.palette.secondary.main}>
+            <Typography align="right" variant="subtitle2">
+              Preprint
+            </Typography>
+          </Box>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Typography variant="subtitle2" color="textSecondary">
+            {authorString}
+          </Typography>
+        </Grid>
+      </Grid>
+      // </div>
+    );
   }
 
   function loadOptions(input) {
@@ -135,9 +147,15 @@ export default withRouter(function SearchBar(props) {
         }
       })}
       styles={{
-        menuList: (base) => ({
+        menuList: base => ({
           ...base,
           maxHeight: "40vh",
+        }),
+        option: base => ({
+          ...base,
+          borderBottom: `0.5px solid #eee`,
+          paddingTop: '15px',
+          paddingBottom: '15px',
         })
       }}
     />

--- a/client/src/views/ViewDialog.js
+++ b/client/src/views/ViewDialog.js
@@ -43,6 +43,15 @@ export default function ViewDialog({ props }) {
     }
   }
 
+  let href
+  if (props.selectedPaper.id && props.selectedPaper.isPreprint) {
+    href = `https://doi.org/${props.selectedPaper.id}`
+  } else if (props.selectedPaper.id) {
+    href = `https://www.ncbi.nlm.nih.gov/pubmed/${props.selectedPaper.id}`
+  } else {
+    href = ''
+  }
+
   return (
     <React.Fragment>
       <DialogTitle className={classes.title}>
@@ -96,10 +105,7 @@ export default function ViewDialog({ props }) {
           leaveDelay={100}
         >
           <a
-            href={props.selectedPaper.id ?
-              "https://www.ncbi.nlm.nih.gov/pubmed/" +
-              props.selectedPaper.id.toString() :
-              ""}
+            href={href}
             target="_blank"
             rel='noopener noreferrer'
             style={{ textDecoration: "none" }}

--- a/extract-subnetwork.js
+++ b/extract-subnetwork.js
@@ -245,7 +245,7 @@ class ExtractSubnetwork {
       body: {
         query: {
           ids: {
-            type: 'paper',
+            type: '_doc',
             values: [node]
           }
         }
@@ -411,8 +411,8 @@ class ExtractSubnetwork {
     // 'stored_neighbours' already contains the edge information, so
     // this object can be parsed to extract edges.
     // for (let type of ['semantic']) {
-    // for (let type of ['citation', 'semantic']) {
-    for (let type of ['citation']) {
+    for (let type of ['citation', 'semantic']) {
+    // for (let type of ['citation']) {
       for (let node of Object.keys(top_results)) {
   
         // Get node edges.
@@ -431,13 +431,13 @@ class ExtractSubnetwork {
           for (let neighbour of node_neighbours) {
             if (top_results[neighbour]) {
               if (type === 'citation') {
-                this.hasCitationEdges[parseInt(node)] = true
+                this.hasCitationEdges[node] = true
                 this.hasCitationEdges[neighbour] = true
               } else {
-                this.hasSemanticEdges[parseInt(node)] = true
+                this.hasSemanticEdges[node] = true
                 this.hasSemanticEdges[neighbour] = true
               }
-              edge_arr.push({ source: parseInt(node), target: neighbour, type });
+              edge_arr.push({ source: node, target: neighbour, type });
             }
           }
         }
@@ -460,7 +460,7 @@ class ExtractSubnetwork {
         size: this.n_top + this.source_nodes.length,
         query: {
           ids: {
-            type: 'paper',
+            type: '_doc',
             values: Object.keys(top_results)
           }
         }
@@ -479,6 +479,7 @@ class ExtractSubnetwork {
       let Journal = source.Journal;
       let Authors = source.Authors;
       let Abstract = source.Abstract;
+      let isPreprint = source.is_preprint;
       let score = top_results[id];
       let hasCitationEdges = this.hasCitationEdges[id]
       let hasSemanticEdges = this.hasSemanticEdges[id]
@@ -491,6 +492,7 @@ class ExtractSubnetwork {
         Journal,
         Authors,
         Abstract,
+        isPreprint,
         score,
         hasCitationEdges,
         hasSemanticEdges,
@@ -531,18 +533,14 @@ class ExtractSubnetwork {
 }
 
 process.on('message', async function (message) {
-  // console.log('parent', message);
 
   let { seeds, indexName, saveState } = message
 
-  // seedrandom('', {state: saveState, global: true})
-
   // Create new 'ExtractSubnetwork' object.
   extSub = new ExtractSubnetwork(
-    seeds, 20000, 0.85, 30, es, indexName, saveState
+    seeds, 5000, 0.85, 30, es, indexName, saveState
   );
 
-  
   // Pass 'extSub' to function to await subgraph computation and send
   // extracted subgraph.
   await send_subgraph(extSub);

--- a/package-lock.json
+++ b/package-lock.json
@@ -910,8 +910,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -929,13 +928,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -948,18 +945,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1062,8 +1056,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1073,7 +1066,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1086,20 +1078,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1116,7 +1105,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1189,8 +1177,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1200,7 +1187,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1276,8 +1262,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1307,7 +1292,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1325,7 +1309,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1364,13 +1347,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/process-subnetwork.js
+++ b/process-subnetwork.js
@@ -29,7 +29,7 @@ function processSubnetwork(message, seeds) {
     if (seeds.includes(node.id)) {
       radius = 32.5
     }
-    return Math.max(5, radius)
+    return Math.max(15, radius)
   }
 
   function formatAuthors(authors) {
@@ -142,6 +142,42 @@ function processSubnetwork(message, seeds) {
           dateString += 'November '
           break
         case '12':
+          dateString += 'December '
+          break
+        case 1:
+          dateString += 'January '
+          break
+        case 2:
+          dateString += 'February '
+          break
+        case 3:
+          dateString += 'March '
+          break
+        case 4:
+          dateString += 'April '
+          break
+        case 5:
+          dateString += 'May'
+          break
+        case 6:
+          dateString += 'June '
+          break
+        case 7:
+          dateString += 'July '
+          break
+        case 8:
+          dateString += 'August '
+          break
+        case 9:
+          dateString += 'September '
+          break
+        case 10:
+          dateString += 'October '
+          break
+        case 11:
+          dateString += 'November '
+          break
+        case 12:
           dateString += 'December '
           break
         default:

--- a/query-es.js
+++ b/query-es.js
@@ -8,19 +8,46 @@ function query_es(query, index_name, es) {
   let fields = ['Title', 'Authors.ForeName', 'Authors.LastName', '_id', 'PubDate.Year', 'Journal.Title', 'Journal.ISO']
 
   // Query Elasticsearch.
+  // let queryRes = es.search({
+  //   index: index_name,
+  //   type: '_doc',
+  //   size: 10,
+  //   body: {
+  //     query: {
+  //       bool: {
+  //         must: {
+  //           multi_match: {
+  //             query: query,
+  //             fields: fields,
+  //             type: 'cross_fields'
+  //           }
+  //         },
+  //         filter: {
+  //           term: {
+  //             has_edges: true
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  // })
+
   let queryRes = es.search({
+    // index: index_name,
     index: index_name,
-    type: 'paper',
-    size: 10,
+    type: '_doc',
+    size: 20,
     body: {
       query: {
         bool: {
           must: {
-            multi_match: {
-              query: query,
-              fields: fields,
-              type: 'cross_fields'
-            }
+            match: {
+              query_field: {
+                query: query,
+                fuzziness: 'AUTO',
+                lenient: true
+              }
+            },
           },
           filter: {
             term: {

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ const es = new elasticsearch.Client({
 });
 
 // Elasticsearch index.
-const indexName = 'papers'
+const indexName = 'papers_reindex'
 
 // Boilerplate
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
This PR adds the following:
- Support for preprints from medRxiv and bioRxiv
- Improved text querying by fuzzy matching `query_field` in Elasticsearch, which contains all relevant searchable text
- Added preprint identifiers in searchbar drop-down
- Citation AND Semantic edges are now displayed. This is so that preprints actually have edges between them. In the future we will need to figure out a better solution (maybe try to parse preprint citations)